### PR TITLE
Trimmed Diarization image size

### DIFF
--- a/diarization/Containerfile
+++ b/diarization/Containerfile
@@ -1,21 +1,17 @@
-FROM nvidia/cuda:11.8.0-devel-ubuntu20.04
-
-COPY ./environment.yaml /environment.yaml
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
 
 # Install necessary packages
 RUN apt-get update && apt-get install -y \
+    git \
     wget \
     bzip2 \
-    git \
+    ffmpeg \
+    python3 \
+    python3-pip \
     ca-certificates
 
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh && \
-    bash /tmp/miniconda.sh -b -p /opt/conda && \
-    rm /tmp/miniconda.sh && \
-    ln -s /opt/conda/bin/conda /usr/local/bin/conda
+COPY ./requirements.txt /requirements.txt
 
-ENV PATH=/opt/conda/bin:$PATH
-
-RUN conda env create --file environment.yaml
+RUN pip install -r requirements.txt
 
 EXPOSE 8888

--- a/diarization/requirements.txt
+++ b/diarization/requirements.txt
@@ -1,0 +1,12 @@
+pytubefix
+pydub
+jupyterlab
+jupyterlab-execute-time
+jupyterlab_vim
+ipywidgets
+
+torch==2.0.0 --index-url https://download.pytorch.org/whl/cu118
+torchvision==0.15.1 --index-url https://download.pytorch.org/whl/cu118
+torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu118
+
+git+https://github.com/m-bain/whisperx.git

--- a/diarization/requirements.txt
+++ b/diarization/requirements.txt
@@ -5,8 +5,8 @@ jupyterlab-execute-time
 jupyterlab_vim
 ipywidgets
 
-torch==2.0.0 --index-url https://download.pytorch.org/whl/cu118
-torchvision==0.15.1 --index-url https://download.pytorch.org/whl/cu118
-torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu118
+torch==2.3.1 --index-url https://download.pytorch.org/whl/cu118
+torchvision==0.18.1 --index-url https://download.pytorch.org/whl/cu118
+torchaudio==2.3.1 --index-url https://download.pytorch.org/whl/cu118
 
 git+https://github.com/m-bain/whisperx.git

--- a/podman-compose.yaml
+++ b/podman-compose.yaml
@@ -16,7 +16,7 @@ services:
     command: [
       "bash",
       "-c",
-      "source activate diarization && jupyter lab --ip=0.0.0.0 --port 8888 --no-browser --allow-root --notebook-dir=/diarization"
+      "jupyter lab --ip=0.0.0.0 --port 8888 --no-browser --allow-root --notebook-dir=/diarization"
     ]
     deploy:
       resources:


### PR DESCRIPTION
Reduced Diarization image size (from 28GB to 16GB) by installing diarization dependencies with pip instead of conda (and reusing the base image CUDA installation). Unfortunately, this errors with the "_Kernel Restarting: the kernel for run-diarization.ipynb appears to have died. It will restart automatically_"

Curiously, the version with the conda environment (currently on `main`) works in Jupyter Notebooks, but bloats the image.

This PR waits on some fix on the WhisperX side addressing this issue (or confirmation of successful tests with bumped dependencies).

Alternatives:
- Manually test other dependency versions
- Use a minimal python image with the CUDA installation done via conda